### PR TITLE
LOG-6 Fix the crash due to Invalid IndexPath of TableView

### DIFF
--- a/Log/MessageViewController.swift
+++ b/Log/MessageViewController.swift
@@ -168,7 +168,10 @@ extension MessageViewController: UITableViewDelegate, UITableViewDataSource {
 extension UITableView {
     func scrollToBottom() {
         let rows = self.numberOfRows(inSection: 0)
-        let indexPath = IndexPath(row: rows - 1, section: 0)
-        self.scrollToRow(at: indexPath, at: .top, animated: false)
+        // This will guarantee rows - 1 >= 0
+        if rows > 0 {
+            let indexPath = IndexPath(row: rows - 1, section: 0)
+                self.scrollToRow(at: indexPath, at: .top, animated: false)
+        }
     }
 }


### PR DESCRIPTION
Add if check of numberOfRows in TableView to avoid the invalid IndexPath to scroll.